### PR TITLE
Don't translate variables

### DIFF
--- a/tests/TranslateStringsTest.php
+++ b/tests/TranslateStringsTest.php
@@ -50,3 +50,25 @@ it('skips translating previously translated strings', function () {
         'My already translated test string' => 'Min redan översatta teststräng',
     ]));
 });
+
+it('can translate with variables', function () {
+    $this->partialMock(Translator::class, function (MockInterface $mock) {
+        $mock->shouldReceive('translateText')
+            ->withAnyArgs()
+            ->once()
+            ->andReturn([
+                new TextResult('Min sträng med <NOTRANSLATE>:variable</NOTRANSLATE>', 'en'),
+            ]);
+    });
+
+    $results = app(TranslateStrings::class)->execute(
+        collect([
+            'My string with :variable' => 'My string with :variable',
+        ]),
+        'sv'
+    );
+
+    expect($results)->toEqual(collect([
+        'My string with :variable' => 'Min sträng med :variable',
+    ]));
+});


### PR DESCRIPTION
This PR introduces better support for variables in strings. We wrap them in a `NOTRANSLATE` XML tag before sending to DeepL, and instruct DeepL to ignore anything within this tag. When we get the data back, we strip away the tag before writing to the file.