### PR TITLE
Support Laravel 11–13 (drop 9/10)

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,13 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [9.*, 10.*, 11.*, 12.*, 13.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
@@ -30,8 +26,6 @@ jobs:
         exclude:
           - laravel: 13.*
             php: 8.2
-          - laravel: 9.*
-            php: 8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
-        laravel: [9.*, 10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [9.*, 10.*, 11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
           - laravel: 9.*
@@ -25,6 +25,13 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
+          - laravel: 9.*
+            php: 8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,20 @@
     "require": {
         "php": "^8.1",
         "deeplcom/deepl-php": "^1.2",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0|^7.0|^8.0",
+        "nunomaduro/collision": "^6.0|^7.0|^8.0|^9.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-        "pestphp/pest": "^1.21|^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^1.1|^2.0|^3.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^1.21|^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^1.1|^2.0|^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
         "phpstan/phpstan-phpunit": "^1.0|^2.0",
-        "phpunit/phpunit": "^9.5|^10.0|^11.0",
+        "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,22 +16,22 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "deeplcom/deepl-php": "^1.2",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0|^7.0|^8.0|^9.0",
+        "nunomaduro/collision": "^8.0|^9.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^1.21|^2.0|^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^1.1|^2.0|^3.0|^4.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
         "phpstan/phpstan-phpunit": "^1.0|^2.0",
-        "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,13 +5,6 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <coverage>
-    <report>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-      <clover outputFile="build/logs/clover.xml"/>
-    </report>
-  </coverage>
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>


### PR DESCRIPTION
## Summary
- Adopts Laravel 11+ as the new baseline: drops Laravel 9 and 10, adds Laravel 13
- `illuminate/contracts` now `^11.0|^12.0|^13.0`; PHP minimum bumped to 8.2 (Laravel 11's floor)
- Bumps `orchestra/testbench`, `nunomaduro/collision`, `pestphp/pest`, `pestphp/pest-plugin-laravel`, and `phpunit/phpunit` constraints to match
- CI matrix now tests PHP 8.2/8.3/8.4 against Laravel 11/12/13 (with L13 excluded on PHP 8.2 since L13 requires PHP 8.3+)
- PHPStan job moved from PHP 8.1 to PHP 8.2

## Test plan
- [ ] CI matrix passes for Laravel 11/12 on PHP 8.2/8.3/8.4
- [ ] Laravel 13 entries pass on PHP 8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)